### PR TITLE
make active the source of truth if we don't want to rely on hover events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export default class TooltipPortal extends PureComponent {
 
   static defaultProps = {
     active: false,
+    hoverEvents: true,
     offset: 10,
     position: 'left',
     tipStyle: {},
@@ -67,7 +68,7 @@ export default class TooltipPortal extends PureComponent {
   }
 
   render () {
-    if ((!this.props.active && !this.state.show && !this.state.hover) || !this.props.parent) return null
+    if ((!this.props.active && !this.state.show && !this.state.hover) || !this.props.parent || (!this.props.active && !this.props.hoverEvents)) return null
 
     return createPortal(
       <Tooltip


### PR DESCRIPTION
the consumer can pass in hoverEvents={false} if they want to control whether or not to show the tooltip based on only the `active` property.  This situation is happening in an app I have where I want to click to open the tooltip and I have clickable content in there, and after a user clicks on an option I want the tooltip to disappear.