### PR TITLE
fix: add checker for Element

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@types/react": "^16.8.17",
     "babel-core": "~6.24.1",
     "babel-loader": "~6.4.1",
     "babel-preset-env": "~1.5.2",
@@ -32,7 +33,7 @@
     "webpack": "~2.3.3"
   },
   "dependencies": {
-    "@types/react": "^16.8.17",
+    "exenv": "~1.2.2",
     "global": "~4.3.2",
     "prop-types": "~15.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "webpack": "~2.3.3"
   },
   "dependencies": {
-    "exenv": "~1.2.2",
     "global": "~4.3.2",
     "prop-types": "~15.6.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,13 @@ import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import document from 'global/document'
 import window from 'global/window'
-import {canUseDOM} from 'exenv'
 
 const TOP = 'top'
 const LEFT = 'left'
 const BOTTOM = 'bottom'
 const RIGHT = 'right'
 
+const canUseDOM = !!(window.document && window.document.createElement)
 const SafeElement = canUseDOM ? window.Element : {}
 
 export default class TooltipPortal extends PureComponent {

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@ export default class TooltipPortal extends PureComponent {
     offset: PropTypes.number,
     position: PropTypes.string,
     tipStyle: PropTypes.object,
-    hoverEvents: PropTypes.boolean,
+    hoverEvents: PropTypes.bool,
     timeout: PropTypes.number,
     className: PropTypes.string
   }

--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,21 @@ import React, { PureComponent } from 'react'
 import { createPortal } from 'react-dom'
 import PropTypes from 'prop-types'
 import document from 'global/document'
+import window from 'global/window'
+import {canUseDOM} from 'exenv'
 
 const TOP = 'top'
 const LEFT = 'left'
 const BOTTOM = 'bottom'
 const RIGHT = 'right'
 
+const SafeElement = canUseDOM ? window.Element : {}
+
 export default class TooltipPortal extends PureComponent {
 
   static propTypes = {
     active: PropTypes.bool.isRequired,
-    parent: PropTypes.instanceOf(Element).isRequired,
+    parent: PropTypes.instanceOf(SafeElement).isRequired,
     children: PropTypes.node.isRequired,
     offset: PropTypes.number,
     position: PropTypes.string,


### PR DESCRIPTION
Another PR 🚀

Noticed that SSR apps would crash without a check for the existence of `Element` used in the propTypes for Tooltip, so I added a conditional check for it.